### PR TITLE
Initial creation of repositories

### DIFF
--- a/otterdog/eclipse-fa3st.jsonnet
+++ b/otterdog/eclipse-fa3st.jsonnet
@@ -7,7 +7,7 @@ orgs.newOrg('eclipse-fa3st') {
     web_commit_signoff_required: false,
     workflows+: {
       actions_can_approve_pull_request_reviews: false,
-      default_workflow_permissions: "write",
+      default_workflow_permissions: "read",
     },
   },
   _repositories+:: [
@@ -17,7 +17,7 @@ orgs.newOrg('eclipse-fa3st') {
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "write",
+        default_workflow_permissions: "read",
       },
     },
     orgs.newRepo('fa3st-registry') {
@@ -26,7 +26,7 @@ orgs.newOrg('eclipse-fa3st') {
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       workflows+: {
-        default_workflow_permissions: "write",
+        default_workflow_permissions: "read",
       },
     },
   ],

--- a/otterdog/eclipse-fa3st.jsonnet
+++ b/otterdog/eclipse-fa3st.jsonnet
@@ -10,4 +10,24 @@ orgs.newOrg('eclipse-fa3st') {
       default_workflow_permissions: "write",
     },
   },
+  _repositories+:: [
+    orgs.newRepo('fa3st-service') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+    },
+    orgs.newRepo('fa3st-registry') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: true,
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+    },
+  ],
 }


### PR DESCRIPTION
To move existing projects (https://github.com/FraunhoferIOSB/FAAAST-Service & https://github.com/FraunhoferIOSB/FAAAST-Registry) to eclipse-fa3st we first need to create the corresponding repositories.